### PR TITLE
Add JetBrains standard .idea directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /asdf/
+
+# JetBrains IDE Config Files
+.idea/


### PR DESCRIPTION
I noticed this locally when making my previous PR, but I wanted to keep the commit separate in case this wasn't desired for this project.