### PR TITLE
docs: update installation to match asdf v0.5.0 command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ golang plugin for [asdf version manager](https://github.com/asdf-vm/asdf)
 ## Install
 
 ```bash
-asdf plugin add golang https://github.com/asdf-community/asdf-golang.git
+asdf plugin-add golang https://github.com/asdf-community/asdf-golang.git
 ```
 
 ## Use


### PR DESCRIPTION
docs: update installation to match asdf v0.5.0 command

asdf v0.5.0 tells you to manage plugins using the format `asdf plugin-{command} ...` rather than `asdf plugin {command} ...`