### PR TITLE
Change command for fish in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To set `GOROOT` in your shell's initialization add the following:
 `. ~/.asdf/plugins/golang/set-env.zsh`  
 
 **fish shell**  
-`. ~/.asdf/plugins/golang/set-env.fish`  
+`source ~/.asdf/plugins/golang/set-env.fish`  
 
 ## When using `go get` or `go install`
 


### PR DESCRIPTION
`.` is deprecated, so replace it with `source` command.

ref: https://fishshell.com/docs/current/cmds/source.html
> . (a single period) is an alias for the source command. The use of . is deprecated in favour of source, and . will be removed in a future version of fish.
