### PR TITLE
Add set-env.sh for bash

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ To set `GOROOT` in your shell's initialization add the following:
 **fish shell**  
 `source ~/.asdf/plugins/golang/set-env.fish`  
 
+**bash shell**
+`. ~/.asdf/plugins/golang/set-env.sh`
+
 ## When using `go get` or `go install`
 
 After using `go get` or `go install` to install a package you need to run `asdf reshim golang` to get any new shims.

--- a/set-env.sh
+++ b/set-env.sh
@@ -1,0 +1,3 @@
+asdf_update_golang_env='go_path="$(asdf which go)"; if [[ -n "${go_path}" ]]; then export GOROOT; GOROOT="$(dirname "$(dirname "${go_path:A}")")"; fi'
+
+PROMPT_COMMAND="${PROMPT_COMMAND};${asdf_update_golang_env}"


### PR DESCRIPTION
I'm using homebrew bash for my shell and wanted to use this plugin. I didn't see a set-env hook for bash, so I added one.

I tested this by adding it directly to my `~/.bash_profile`, and it seems to be working!