### PR TITLE
Handle "No version is set" case when setting GOROOT

### DIFF
--- a/set-env.fish
+++ b/set-env.fish
@@ -1,5 +1,5 @@
 function asdf_update_golang_env --on-event fish_prompt
-  set --local go_path (asdf which go)
+  set --local go_path (asdf which go 2>/dev/null)
   if test -n "$go_path"
     set --local full_path (builtin realpath "$go_path")
 

--- a/set-env.zsh
+++ b/set-env.zsh
@@ -1,6 +1,6 @@
 asdf_update_golang_env() {
   local go_path
-  go_path="$(asdf which go)"
+  go_path="$(asdf which go 2>/dev/null)"
   if [[ -n "${go_path}" ]]; then
     export GOROOT
     GOROOT="$(dirname "$(dirname "${go_path:A}")")"


### PR DESCRIPTION
When using https://github.com/asdf-community/asdf-golang?tab=readme-ov-file#goroot to set GOROOT and there is no default go version set, running any shell command was printing out:

```
No version is set for command go
Consider adding one of the following versions in your config file at ...
```