### PR TITLE
Add riscv64 support since builds are now available

### DIFF
--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -30,6 +30,7 @@ get_arch() {
     aarch64 | arm64) arch="arm64" ;;
     ppc64le) arch="ppc64le" ;;
     loongarch64 | loong64) arch="loong64" ;;
+    riscv64) arch="riscv64" ;;
     *)
       fail "Arch '${arch_check}' not supported!"
       ;;


### PR DESCRIPTION
The official golang site now makes riscv64 builds available for linux. This adds the correct `uanem -m` match in the helper. Tested on a Banana Pi BPI-F3 running Ubuntu 20.04, worked like a charm.