### PR TITLE
fix: improve setup instructions and enforce consistent GOBIN usage  

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,25 +23,31 @@ asdf plugin add golang https://github.com/asdf-community/asdf-golang.git
 
 ## Use
 
-Check the [asdf](https://github.com/asdf-vm/asdf) readme for instructions on how to install & manage versions of go.
+To ensure the Golang environment variables are correctly set when using the `asdf` Go plugin (`asdf-golang`), you should source the appropriate `set-env` script for your shell. This is particularly important if you've customized the `asdf` data directory using the `ASDF_DATA_DIR` environment variable. Below are instructions for various shells:
 
-## `GOROOT`
+- **Zsh (`.zshrc`):**
 
-To set `GOROOT` in your shell's initialization add the following:
+  ```bash
+  . ${ASDF_DATA_DIR:-$HOME/.asdf}/plugins/golang/set-env.zsh
+  ```
 
-**zsh shell**  
-`. ~/.asdf/plugins/golang/set-env.zsh`  
+- **Bash (`.bashrc`):**
 
-**fish shell**  
-`source ~/.asdf/plugins/golang/set-env.fish`  
+  ```bash
+  . ${ASDF_DATA_DIR:-$HOME/.asdf}/plugins/golang/set-env.bash
+  ```
 
-**nushell shell**
-Add this to your env.nu
-`source ('~/.asdf/plugins/golang/set-env.nu')`
+- **Fish (`config.fish`):**
 
-**bash shell**
-Add this to your .bashrc:
-`. ~/.asdf/plugins/golang/set-env.bash` 
+  ```fish
+  source (echo $ASDF_DATA_DIR | if test -z $it; echo $HOME/.asdf; else echo $it; end)/plugins/golang/set-env.fish
+  ```
+
+- **Nushell (`env.nu`):**
+
+  ```nu
+  source (if ($env.ASDF_DATA_DIR | empty?) { echo $nu.env.HOME/.asdf } { echo $env.ASDF_DATA_DIR })/plugins/golang/set-env.nu
+  ```
 
 ## When using `go get` or `go install`
 

--- a/bin/exec-env
+++ b/bin/exec-env
@@ -8,4 +8,8 @@ if [ "${ASDF_INSTALL_VERSION}" != 'system' ]; then
   if [[ "unset" == "${GOPATH:-unset}" ]]; then
     export GOPATH=$ASDF_INSTALL_PATH/packages
   fi
+
+  if [[ "unset" == "${GOBIN:-unset}" ]]; then
+    export GOBIN=$ASDF_INSTALL_PATH/bin
+  fi
 fi

--- a/bin/install
+++ b/bin/install
@@ -51,12 +51,14 @@ install_default_go_pkgs() {
 
       GOROOT="$ASDF_INSTALL_PATH/go" \
         GOPATH="$ASDF_INSTALL_PATH/packages" \
+        GOBIN="$ASDF_INSTALL_PATH/bin" \
         PATH="$go_path:$PATH" \
         go install "$name" >/dev/null && rc=$? || rc=$?
     else
       GOROOT="$ASDF_INSTALL_PATH/go" \
         GOPATH="$ASDF_INSTALL_PATH/packages" \
         PATH="$go_path:$PATH" \
+        GOBIN="$ASDF_INSTALL_PATH/bin" \
         go get -u "$name" >/dev/null && rc=$? || rc=$?
     fi
 

--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-echo -n "bin go/bin packages/bin"
+echo -n "bin go/bin"


### PR DESCRIPTION
This PR includes two changes:  

- Improves README instructions to better guide new users.  
- Ensures that GOBIN is always set and used consistently, preventing binaries from being installed in unexpected locations.  

closes #151 
closes #150