### PR TITLE
Add Auto Reshim, closes #131

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SRCFILES = $(shell git ls-files "bin/**" "lib/**" "spec/**" "test-fixtures/*.sh")
+SRCFILES = $(shell git ls-files "bin/**" "lib/**" "shims/**" "spec/**" "test-fixtures/*.sh")
 SHFMT_BASE_FLAGS = -s -i 2 -ci
 
 format:

--- a/bin/list-bin-paths
+++ b/bin/list-bin-paths
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
-echo -n "bin go/bin"
+# shims takes precedence over the regular go binary
+echo -n "shims bin go/bin"

--- a/shims/go
+++ b/shims/go
@@ -49,6 +49,18 @@ resolve_canon_go() {
     fi
   fi
 
+  # Resolve based on current version
+  local current_version
+  current_version=$(asdf current golang 2>/dev/null | awk '{print $2}' | head -n1)
+  if [[ -n "$current_version" ]]; then
+    local asdf_data_dir="${ASDF_DATA_DIR:-$HOME/.asdf}"
+    local asdf_go_path="$asdf_data_dir/installs/golang/$current_version/go/bin/go"
+    if [[ -x "$asdf_go_path" ]]; then
+      echo "$asdf_go_path"
+      return
+    fi
+  fi
+
   # Fallback to PATH, but avoid recursion
   local go_path
   go_path=$(command -v go 2>/dev/null || true)
@@ -67,6 +79,7 @@ wrap_go_and_reshim() {
 
   if should_reshim "$@"; then
     # Run original command
+    echo "Running original Go command and reshim:" "$canon_go_path" "$@"
     "$canon_go_path" "$@"
     local exit_code=$?
 
@@ -83,6 +96,7 @@ wrap_go_and_reshim() {
     return $exit_code
   else
     # No reshim needed, run original command
+    echo "Running original Go command:" "$canon_go_path" "$@"
     exec "$canon_go_path" "$@"
   fi
 }

--- a/shims/go
+++ b/shims/go
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# This script wraps golang and runs `asdf reshim` after install and get commands.
+# Any other cases are passed-through to golang.
+#
+# To skip reshimming, set the environment variable `ASDF_GOLANG_SKIP_RESHIM=1`.
+#
+# Inspired by asdf-nodejs: https://github.com/asdf-vm/asdf-nodejs/blob/b2d06a768d9a14186db72018df10604bdb384436/shims/npm
+
+should_reshim() {
+  if [[ "${ASDF_GOLANG_SKIP_RESHIM:-}" == "1" ]]; then
+    # Skip reshimming if the environment variable `ASDF_GOLANG_SKIP_RESHIM` is set
+    return 1
+  fi
+
+  for arg in "$@"; do
+    case "$arg" in
+      install)
+        return 0
+        ;;
+      get)
+        return 0
+        ;;
+    esac
+  done
+
+  return 1
+}
+
+resolve_canon_go() {
+  if [[ -n "${ASDF_GOLANG_CANON_GO_PATH:-}" ]]; then
+    echo "$ASDF_GOLANG_CANON_GO_PATH"
+    return
+  fi
+
+  # Current asdf installation
+  local go_path
+  go_path=$(command -v go 2>/dev/null || true)
+  
+  if [[ -z "$go_path" || "$go_path" == *"/shims/go" ]]; then
+    # Not found in PATH, find it in the current installation
+    local install_path="${ASDF_INSTALL_PATH:-}"
+    if [[ -n "$install_path" && -x "$install_path/go/bin/go" ]]; then
+      go_path="$install_path/go/bin/go"
+    else
+      # Fallback: find through asdf
+      local current_version
+      current_version=$(asdf current golang 2>/dev/null | awk '{print $2}' || echo "")
+      if [[ -n "$current_version" ]]; then
+        local asdf_data_dir="${ASDF_DATA_DIR:-$HOME/.asdf}"
+        go_path="$asdf_data_dir/installs/golang/$current_version/go/bin/go"
+      fi
+    fi
+  fi
+
+  if [[ -x "$go_path" ]]; then
+    echo "$go_path"
+  else
+    # Fallback: system go
+    echo "go"
+  fi
+}
+
+wrap_go_and_reshim() {
+  local canon_go_path
+  canon_go_path=$(resolve_canon_go)
+
+  if should_reshim "$@"; then
+    # Run original go command
+    "$canon_go_path" "$@"
+    local exit_code=$?
+    
+    if [[ $exit_code -eq 0 ]]; then
+      # Command succeeded, reshim
+      echo "Reshimming asdf golang..." >&2
+      asdf reshim golang
+    fi
+    
+    return $exit_code
+  else
+    # Run original go command, no reshimming needed
+    exec "$canon_go_path" "$@"
+  fi
+}
+
+# Call the wrapper function
+wrap_go_and_reshim "$@"

--- a/shims/go
+++ b/shims/go
@@ -26,16 +26,19 @@ determine_plugin_name() {
   local plugin_name=""
 
   if [[ -n "${ASDF_PLUGIN_PATH:-}" ]]; then
+    echo "Using ASDF_PLUGIN_PATH: ${ASDF_PLUGIN_PATH}" >&2
     plugin_name=$(basename "${ASDF_PLUGIN_PATH}")
   fi
 
   if [[ -z "$plugin_name" ]]; then
     # List available plugins
+    echo "Listing available plugins..." >&2
     plugin_name=$(asdf plugin-list | grep -o '[a-zA-Z0-9_-]*' | grep -i golang 2>/dev/null | head -n1)
   fi
 
   if [[ -z "$plugin_name" ]]; then
     # Extract from directory structure
+    echo "Determining plugin name from directory structure..." >&2
     local script_dir
     script_dir="$(cd "$(dirname "$self")" && pwd)"
     local plugin_dir
@@ -77,6 +80,7 @@ resolve_canon_go() {
   if [[ -n "$p_where" ]]; then
     p_where="$p_where/go/bin/go"
     if [[ -x "$p_where" && "$p_where" != "$self" ]]; then
+      echo "Using asdf where golang from: $p_where" >&2
       echo "$p_where"
       return
     fi
@@ -89,10 +93,13 @@ resolve_canon_go() {
     local install_base_path
 
     if [[ -n "${ASDF_INSTALL_PATH:-}" ]]; then
+      echo "Using ASDF_INSTALL_PATH: ${ASDF_INSTALL_PATH}" >&2
       install_base_path="${ASDF_INSTALL_PATH}"
     elif [[ -n "${ASDF_PLUGIN_PATH:-}" ]]; then
+      echo "Using ASDF_PLUGIN_PATH: ${ASDF_PLUGIN_PATH}" >&2
       install_base_path="${ASDF_PLUGIN_PATH%/*}"
     else
+      echo "Using ASDF_DATA_DIR: ${ASDF_DATA_DIR:-$HOME/.asdf}" >&2
       install_base_path="${ASDF_DATA_DIR:-$HOME/.asdf}"
     fi
 
@@ -108,6 +115,7 @@ resolve_canon_go() {
   local go_path
   go_path=$(command -v go 2>/dev/null || true)
   if [[ -n "$go_path" && -x "$go_path" && "$go_path" != "$self" && "$go_path" != *"/shims/go" ]]; then
+    echo "Using system go from: $go_path" >&2
     echo "$go_path"
     return
   fi

--- a/shims/go
+++ b/shims/go
@@ -11,20 +11,35 @@ set -euo pipefail
 # Inspired by asdf-nodejs: https://github.com/asdf-vm/asdf-nodejs/blob/b2d06a768d9a14186db72018df10604bdb384436/shims/npm
 
 should_reshim() {
-  if [[ "${ASDF_GOLANG_SKIP_RESHIM:-}" == "1" ]]; then
-    # Skip reshimming if the environment variable `ASDF_GOLANG_SKIP_RESHIM` is set
-    return 1
-  fi
+  # Skip reshim if ASDF_GOLANG_SKIP_RESHIM is set
+  [[ "${ASDF_GOLANG_SKIP_RESHIM:-}" == "1" ]] && return 1
 
-  # Only consider the first arg as the go subcommand to avoid false positives (e.g., `go help install`)
+  # Handle install command
   local subcmd="${1-}"
-  case "$subcmd" in
-    install)
-      return 0
-      ;;
-  esac
+  [[ "$subcmd" == "install" ]] && return 0
 
   return 1
+}
+
+determine_plugin_name() {
+  local self="${1:-}"
+  local plugin_name=""
+
+  if command -v asdf >/dev/null 2>&1; then
+    # List available plugins
+    plugin_name=$(asdf plugin-list | grep -o '[a-zA-Z0-9_-]*' | grep -i golang 2>/dev/null | head -n1)
+  fi
+
+  if [[ -z "$plugin_name" ]]; then
+    # Extract from directory structure
+    local script_dir
+    script_dir="$(cd "$(dirname "$self")" && pwd)"
+    local plugin_dir
+    plugin_dir="$(cd "$script_dir/.." && pwd)"
+    plugin_name="$(basename "$plugin_dir")"
+  fi
+
+  echo "$plugin_name"
 }
 
 resolve_canon_go() {
@@ -49,12 +64,16 @@ resolve_canon_go() {
     fi
   fi
 
+  # Determine the plugin name dynamically
+  local plugin_name
+  plugin_name=$(determine_plugin_name "$self")
+
   # Resolve based on current version
   local current_version
-  current_version=$(asdf current golang 2>/dev/null | awk '{print $2}' | head -n1)
+  current_version=$(asdf current "$plugin_name" 2>/dev/null | awk '{print $2}' | head -n1)
   if [[ -n "$current_version" ]]; then
     local asdf_data_dir="${ASDF_DATA_DIR:-$HOME/.asdf}"
-    local asdf_go_path="$asdf_data_dir/installs/golang/$current_version/go/bin/go"
+    local asdf_go_path="$asdf_data_dir/installs/$plugin_name/$current_version/go/bin/go"
     if [[ -x "$asdf_go_path" ]]; then
       echo "$asdf_go_path"
       return
@@ -69,7 +88,12 @@ resolve_canon_go() {
     return
   fi
 
-  echo "Could not resolve real Go binary." >&2
+  # Better error message with helpful instructions
+  echo "No version of $plugin_name set. Please run one of the following:" >&2
+  echo "  asdf global $plugin_name <version>" >&2
+  echo "  asdf local $plugin_name <version>" >&2
+  echo "  asdf install $plugin_name <version>" >&2
+  echo "See 'asdf list all $plugin_name' for available versions." >&2
   exit 127
 }
 
@@ -77,28 +101,22 @@ wrap_go_and_reshim() {
   local canon_go_path
   canon_go_path=$(resolve_canon_go)
 
-  if should_reshim "$@"; then
-    # Run original command
-    echo "Running original Go command and reshim:" "$canon_go_path" "$@"
-    "$canon_go_path" "$@"
-    local exit_code=$?
-
-    if [[ $exit_code -eq 0 ]]; then
-      if command -v asdf >/dev/null 2>&1; then
-        # Reshim asdf golang
-        echo "Reshimming asdf golang..." >&2
-        if ! asdf reshim golang; then
-          echo "Warning: asdf reshim failed." >&2
-        fi
-      fi
-    fi
-
-    return $exit_code
-  else
-    # No reshim needed, run original command
-    echo "Running original Go command:" "$canon_go_path" "$@"
+  if ! should_reshim "$@"; then
+    # No reshim needed, execute directly
     exec "$canon_go_path" "$@"
   fi
+
+  # Run original command (reshim needed)
+  "$canon_go_path" "$@"
+  local exit_code=$?
+
+  # Only reshim if the command succeeded and asdf is available
+  if [[ $exit_code -eq 0 ]] && command -v asdf >/dev/null 2>&1; then
+    echo "Reshimming asdf golang..." >&2
+    asdf reshim golang || echo "Warning: asdf reshim failed." >&2
+  fi
+
+  return $exit_code
 }
 
 # Call the wrapper function

--- a/shims/go
+++ b/shims/go
@@ -25,7 +25,11 @@ determine_plugin_name() {
   local self="${1:-}"
   local plugin_name=""
 
-  if command -v asdf >/dev/null 2>&1; then
+  if [[ -n "${ASDF_PLUGIN_PATH:-}" ]]; then
+    plugin_name=$(basename "${ASDF_PLUGIN_PATH}")
+  fi
+
+  if [[ -z "$plugin_name" ]] && command -v asdf >/dev/null 2>&1; then
     # List available plugins
     plugin_name=$(asdf plugin-list | grep -o '[a-zA-Z0-9_-]*' | grep -i golang 2>/dev/null | head -n1)
   fi
@@ -67,13 +71,24 @@ resolve_canon_go() {
   # Determine the plugin name dynamically
   local plugin_name
   plugin_name=$(determine_plugin_name "$self")
+  echo "Plugin name: $plugin_name"
 
-  # Resolve based on current version
   local current_version
-  current_version=$(asdf current "$plugin_name" 2>/dev/null | awk '{print $2}' | head -n1)
+  current_version="${ASDF_INSTALL_VERSION:-$(asdf current "$plugin_name" 2>/dev/null | awk '{print $2}' | head -n1)}"
+
   if [[ -n "$current_version" ]]; then
-    local asdf_data_dir="${ASDF_DATA_DIR:-$HOME/.asdf}"
-    local asdf_go_path="$asdf_data_dir/installs/$plugin_name/$current_version/go/bin/go"
+    local install_base_path
+
+    if [[ -n "${ASDF_INSTALL_PATH:-}" ]]; then
+      install_base_path="${ASDF_INSTALL_PATH}"
+    elif [[ -n "${ASDF_PLUGIN_PATH:-}" ]]; then
+      install_base_path="${ASDF_PLUGIN_PATH%/*}"
+    else
+      local asdf_data_dir="${ASDF_DATA_DIR:-$HOME/.asdf}"
+      install_base_path="$asdf_data_dir/"
+    fi
+
+    local asdf_go_path="$install_base_path/installs/$plugin_name/$current_version/go/bin/go"
     if [[ -x "$asdf_go_path" ]]; then
       echo "$asdf_go_path"
       return
@@ -88,7 +103,6 @@ resolve_canon_go() {
     return
   fi
 
-  # Better error message with helpful instructions
   echo "No version of $plugin_name set. Please run one of the following:" >&2
   echo "  asdf global $plugin_name <version>" >&2
   echo "  asdf local $plugin_name <version>" >&2
@@ -98,6 +112,11 @@ resolve_canon_go() {
 }
 
 wrap_go_and_reshim() {
+  echo "ASDF_INSTALL_PATH: $ASDF_INSTALL_PATH"
+  echo "ASDF_PLUGIN_PATH: $ASDF_PLUGIN_PATH"
+  echo "ASDF_DATA_DIR: $ASDF_DATA_DIR"
+  echo "ASDF_INSTALL_VERSION: $ASDF_INSTALL_VERSION"
+
   local canon_go_path
   canon_go_path=$(resolve_canon_go)
 

--- a/shims/go
+++ b/shims/go
@@ -35,32 +35,42 @@ resolve_canon_go() {
     return
   fi
 
-  # Current asdf installation
+  # Try PATH
   local go_path
   go_path=$(command -v go 2>/dev/null || true)
-  
+
   if [[ -z "$go_path" || "$go_path" == *"/shims/go" ]]; then
-    # Not found in PATH, find it in the current installation
+    # Try ASDF_INSTALL_PATH
     local install_path="${ASDF_INSTALL_PATH:-}"
     if [[ -n "$install_path" && -x "$install_path/go/bin/go" ]]; then
-      go_path="$install_path/go/bin/go"
-    else
-      # Fallback: find through asdf
-      local current_version
-      current_version=$(asdf current golang 2>/dev/null | awk '{print $2}' || echo "")
-      if [[ -n "$current_version" ]]; then
-        local asdf_data_dir="${ASDF_DATA_DIR:-$HOME/.asdf}"
-        go_path="$asdf_data_dir/installs/golang/$current_version/go/bin/go"
+      echo "$install_path/go/bin/go"
+      return
+    fi
+
+    # Try asdf current version
+    local current_version
+    current_version=$(asdf current golang 2>/dev/null | awk '{print $2}' | head -n1)
+    if [[ -n "$current_version" ]]; then
+      local asdf_data_dir="${ASDF_DATA_DIR:-$HOME/.asdf}"
+      local asdf_go_path="$asdf_data_dir/installs/golang/$current_version/go/bin/go"
+      if [[ -x "$asdf_go_path" ]]; then
+        echo "$asdf_go_path"
+        return
       fi
     fi
+  elif [[ -x "$go_path" ]]; then
+    echo "$go_path"
+    return
   fi
 
-  if [[ -x "$go_path" ]]; then
-    echo "$go_path"
-  else
-    # Fallback: system go
-    echo "go"
+  if [[ "$(command -v go 2>/dev/null)" == "$0" ]]; then
+    # Avoid recursion
+    echo "Could not resolve real Go binary (recursion detected)." >&2
+    exit 127
   fi
+
+  # Fallback: system go
+  echo "go"
 }
 
 wrap_go_and_reshim() {

--- a/shims/go
+++ b/shims/go
@@ -14,9 +14,9 @@ should_reshim() {
   # Skip reshim if ASDF_GOLANG_SKIP_RESHIM is set
   [[ "${ASDF_GOLANG_SKIP_RESHIM:-}" == "1" ]] && return 1
 
-  # Handle install command
+  # Handle install and get commands
   local subcmd="${1-}"
-  [[ "$subcmd" == "install" ]] && return 0
+  [[ "$subcmd" == "install" || "$subcmd" == "get" ]] && return 0
 
   return 1
 }
@@ -26,19 +26,12 @@ determine_plugin_name() {
   local plugin_name=""
 
   if [[ -n "${ASDF_PLUGIN_PATH:-}" ]]; then
-    echo "Using ASDF_PLUGIN_PATH: ${ASDF_PLUGIN_PATH}" >&2
+    # Plugin path provided
     plugin_name=$(basename "${ASDF_PLUGIN_PATH}")
   fi
 
   if [[ -z "$plugin_name" ]]; then
-    # List available plugins
-    echo "Listing available plugins..." >&2
-    plugin_name=$(asdf plugin-list | grep -o '[a-zA-Z0-9_-]*' | grep -i golang 2>/dev/null | head -n1)
-  fi
-
-  if [[ -z "$plugin_name" ]]; then
     # Extract from directory structure
-    echo "Determining plugin name from directory structure..." >&2
     local script_dir
     script_dir="$(cd "$(dirname "$self")" && pwd)"
     local plugin_dir
@@ -46,11 +39,34 @@ determine_plugin_name() {
     plugin_name="$(basename "$plugin_dir")"
   fi
 
+  if [[ -z "$plugin_name" ]]; then
+    # Default to golang
+    plugin_name="golang"
+  fi
+  
+  if ! command -v asdf >/dev/null 2>&1; then
+    # Return plugin name without validation, asdf is not available
+    echo "$plugin_name"
+    return
+  fi
+
+  # Check if asdf plugin list contains plugin
+  if ! asdf plugin-list | grep -q "^${plugin_name}$"; then
+    echo "Error: Plugin '${plugin_name}' not found in asdf plugin list." >&2
+    exit 1
+  fi
+
   echo "$plugin_name"
 }
 
+__ASDF_GOLANG_SELF="${BASH_SOURCE[0]:-$0}"
+readonly __ASDF_GOLANG_SELF
+__ASDF_GOLANG_PLUGIN_NAME="$(determine_plugin_name "${__ASDF_GOLANG_SELF}")" || __ASDF_GOLANG_PLUGIN_NAME="golang"
+readonly __ASDF_GOLANG_PLUGIN_NAME
+
 resolve_canon_go() {
-  local self="${BASH_SOURCE[0]:-$0}"
+  local self="${__ASDF_GOLANG_SELF}"
+  local plugin_name="${__ASDF_GOLANG_PLUGIN_NAME:-golang}"
 
   # Check if ASDF_GOLANG_CANON_GO_PATH is set and valid
   if [[ -n "${ASDF_GOLANG_CANON_GO_PATH:-}" ]]; then
@@ -70,17 +86,12 @@ resolve_canon_go() {
     return
   fi
 
-  # Determine the plugin name dynamically
-  local plugin_name
-  plugin_name=$(determine_plugin_name "$self")
-
   # Resolve using asdf where
   local p_where
   p_where=$(asdf where "$plugin_name" 2>/dev/null || true)
   if [[ -n "$p_where" ]]; then
     p_where="$p_where/go/bin/go"
     if [[ -x "$p_where" && "$p_where" != "$self" ]]; then
-      echo "Using asdf where golang from: $p_where" >&2
       echo "$p_where"
       return
     fi
@@ -93,13 +104,10 @@ resolve_canon_go() {
     local install_base_path
 
     if [[ -n "${ASDF_INSTALL_PATH:-}" ]]; then
-      echo "Using ASDF_INSTALL_PATH: ${ASDF_INSTALL_PATH}" >&2
       install_base_path="${ASDF_INSTALL_PATH}"
     elif [[ -n "${ASDF_PLUGIN_PATH:-}" ]]; then
-      echo "Using ASDF_PLUGIN_PATH: ${ASDF_PLUGIN_PATH}" >&2
       install_base_path="${ASDF_PLUGIN_PATH%/*}"
     else
-      echo "Using ASDF_DATA_DIR: ${ASDF_DATA_DIR:-$HOME/.asdf}" >&2
       install_base_path="${ASDF_DATA_DIR:-$HOME/.asdf}"
     fi
 
@@ -115,7 +123,6 @@ resolve_canon_go() {
   local go_path
   go_path=$(command -v go 2>/dev/null || true)
   if [[ -n "$go_path" && -x "$go_path" && "$go_path" != "$self" && "$go_path" != *"/shims/go" ]]; then
-    echo "Using system go from: $go_path" >&2
     echo "$go_path"
     return
   fi
@@ -131,11 +138,17 @@ resolve_canon_go() {
 wrap_go_and_reshim() {
   if ! command -v asdf >/dev/null 2>&1; then
     echo "Warning: asdf command not found. Executing go directly." >&2
-    exec go "$@"
+    exec command go "$@"
   fi
 
+  local plugin_name
+  plugin_name="${__ASDF_GOLANG_PLUGIN_NAME:-golang}"
+
   local canon_go_path
-  canon_go_path=$(resolve_canon_go)
+  canon_go_path=$(resolve_canon_go) || {
+    echo "Error: Failed to resolve Go executable path" >&2
+    exit 1
+  }
 
   if ! should_reshim "$@"; then
     # Execute directly, no reshim needed
@@ -146,12 +159,12 @@ wrap_go_and_reshim() {
   local exit_code=$?
   if [[ $exit_code -eq 0 ]]; then
     # Command succeeded, reshim
-    echo "Reshimming asdf golang..." >&2
-    asdf reshim golang || echo "Warning: asdf reshim failed." >&2
+    echo "Reshimming asdf ${plugin_name}..." >&2
+    asdf reshim "${plugin_name}" || echo "Warning: asdf reshim failed." >&2
   fi
 
   return $exit_code
 }
 
-# Call the wrapper function
+# Entry point
 wrap_go_and_reshim "$@"

--- a/shims/go
+++ b/shims/go
@@ -29,7 +29,7 @@ determine_plugin_name() {
     plugin_name=$(basename "${ASDF_PLUGIN_PATH}")
   fi
 
-  if [[ -z "$plugin_name" ]] && command -v asdf >/dev/null 2>&1; then
+  if [[ -z "$plugin_name" ]]; then
     # List available plugins
     plugin_name=$(asdf plugin-list | grep -o '[a-zA-Z0-9_-]*' | grep -i golang 2>/dev/null | head -n1)
   fi
@@ -49,32 +49,42 @@ determine_plugin_name() {
 resolve_canon_go() {
   local self="${BASH_SOURCE[0]:-$0}"
 
-  # User provided
+  # Check if ASDF_GOLANG_CANON_GO_PATH is set and valid
   if [[ -n "${ASDF_GOLANG_CANON_GO_PATH:-}" ]]; then
     local p="$ASDF_GOLANG_CANON_GO_PATH"
     if [[ -x "$p" && "$p" != "$self" && "$p" != *"/shims/go" ]]; then
       echo "$p"
       return
     fi
+    echo "Warning: ASDF_GOLANG_CANON_GO_PATH is set but not valid." >&2
   fi
 
-  # Resolve using asdf
-  if command -v asdf >/dev/null 2>&1; then
-    local p
-    p=$(asdf which go 2>/dev/null || true)
-    if [[ -n "$p" && -x "$p" && "$p" != "$self" ]]; then
-      echo "$p"
-      return
-    fi
+  # Resolve using asdf which
+  local p_which
+  p_which=$(asdf which go 2>/dev/null || true)
+  if [[ -n "$p_which" && -x "$p_which" && "$p_which" != "$self" ]]; then
+    echo "$p_which"
+    return
   fi
 
   # Determine the plugin name dynamically
   local plugin_name
   plugin_name=$(determine_plugin_name "$self")
 
+  # Resolve using asdf where
+  local p_where
+  p_where=$(asdf where "$plugin_name" 2>/dev/null || true)
+  if [[ -n "$p_where" ]]; then
+    p_where="$p_where/go/bin/go"
+    if [[ -x "$p_where" && "$p_where" != "$self" ]]; then
+      echo "$p_where"
+      return
+    fi
+  fi
+
+  # Resolve using asdf current and variables
   local current_version
   current_version="${ASDF_INSTALL_VERSION:-$(asdf current "$plugin_name" 2>/dev/null | awk '{print $2}' | head -n1)}"
-
   if [[ -n "$current_version" ]]; then
     local install_base_path
 
@@ -83,13 +93,13 @@ resolve_canon_go() {
     elif [[ -n "${ASDF_PLUGIN_PATH:-}" ]]; then
       install_base_path="${ASDF_PLUGIN_PATH%/*}"
     else
-      local asdf_data_dir="${ASDF_DATA_DIR:-$HOME/.asdf}"
-      install_base_path="$asdf_data_dir"
+      install_base_path="${ASDF_DATA_DIR:-$HOME/.asdf}"
     fi
 
-    local asdf_go_path="$install_base_path/installs/$plugin_name/$current_version/go/bin/go"
-    if [[ -x "$asdf_go_path" ]]; then
-      echo "$asdf_go_path"
+    local p
+    p="$install_base_path/installs/$plugin_name/$current_version/go/bin/go"
+    if [[ -x "$p" ]]; then
+      echo "$p"
       return
     fi
   fi
@@ -111,25 +121,23 @@ resolve_canon_go() {
 }
 
 wrap_go_and_reshim() {
-  echo "ASDF_INSTALL_PATH: ${ASDF_INSTALL_PATH:-}"
-  echo "ASDF_PLUGIN_PATH: ${ASDF_PLUGIN_PATH:-}"
-  echo "ASDF_DATA_DIR: ${ASDF_DATA_DIR:-}"
-  echo "ASDF_INSTALL_VERSION: ${ASDF_INSTALL_VERSION:-}"
+  if ! command -v asdf >/dev/null 2>&1; then
+    echo "Warning: asdf command not found. Executing go directly." >&2
+    exec go "$@"
+  fi
 
   local canon_go_path
   canon_go_path=$(resolve_canon_go)
 
   if ! should_reshim "$@"; then
-    # No reshim needed, execute directly
+    # Execute directly, no reshim needed
     exec "$canon_go_path" "$@"
   fi
 
-  # Run original command (reshim needed)
   "$canon_go_path" "$@"
   local exit_code=$?
-
-  # Only reshim if the command succeeded and asdf is available
-  if [[ $exit_code -eq 0 ]] && command -v asdf >/dev/null 2>&1; then
+  if [[ $exit_code -eq 0 ]]; then
+    # Command succeeded, reshim
     echo "Reshimming asdf golang..." >&2
     asdf reshim golang || echo "Warning: asdf reshim failed." >&2
   fi

--- a/shims/go
+++ b/shims/go
@@ -112,10 +112,10 @@ resolve_canon_go() {
 }
 
 wrap_go_and_reshim() {
-  echo "ASDF_INSTALL_PATH: $ASDF_INSTALL_PATH"
-  echo "ASDF_PLUGIN_PATH: $ASDF_PLUGIN_PATH"
-  echo "ASDF_DATA_DIR: $ASDF_DATA_DIR"
-  echo "ASDF_INSTALL_VERSION: $ASDF_INSTALL_VERSION"
+  echo "ASDF_INSTALL_PATH: ${ASDF_INSTALL_PATH:-}"
+  echo "ASDF_PLUGIN_PATH: ${ASDF_PLUGIN_PATH:-}"
+  echo "ASDF_DATA_DIR: ${ASDF_DATA_DIR:-}"
+  echo "ASDF_INSTALL_VERSION: ${ASDF_INSTALL_VERSION:-}"
 
   local canon_go_path
   canon_go_path=$(resolve_canon_go)

--- a/shims/go
+++ b/shims/go
@@ -71,7 +71,6 @@ resolve_canon_go() {
   # Determine the plugin name dynamically
   local plugin_name
   plugin_name=$(determine_plugin_name "$self")
-  echo "Plugin name: $plugin_name"
 
   local current_version
   current_version="${ASDF_INSTALL_VERSION:-$(asdf current "$plugin_name" 2>/dev/null | awk '{print $2}' | head -n1)}"
@@ -85,7 +84,7 @@ resolve_canon_go() {
       install_base_path="${ASDF_PLUGIN_PATH%/*}"
     else
       local asdf_data_dir="${ASDF_DATA_DIR:-$HOME/.asdf}"
-      install_base_path="$asdf_data_dir/"
+      install_base_path="$asdf_data_dir"
     fi
 
     local asdf_go_path="$install_base_path/installs/$plugin_name/$current_version/go/bin/go"

--- a/shims/go
+++ b/shims/go
@@ -6,6 +6,7 @@ set -euo pipefail
 # Any other cases are passed-through to golang.
 #
 # To skip reshimming, set the environment variable `ASDF_GOLANG_SKIP_RESHIM=1`.
+# To set go path, use the environment variable `ASDF_GOLANG_CANON_GO_PATH`.
 #
 # Inspired by asdf-nodejs: https://github.com/asdf-vm/asdf-nodejs/blob/b2d06a768d9a14186db72018df10604bdb384436/shims/npm
 
@@ -15,62 +16,49 @@ should_reshim() {
     return 1
   fi
 
-  for arg in "$@"; do
-    case "$arg" in
-      install)
-        return 0
-        ;;
-      get)
-        return 0
-        ;;
-    esac
-  done
+  # Only consider the first arg as the go subcommand to avoid false positives (e.g., `go help install`)
+  local subcmd="${1-}"
+  case "$subcmd" in
+    install)
+      return 0
+      ;;
+  esac
 
   return 1
 }
 
 resolve_canon_go() {
+  local self="${BASH_SOURCE[0]:-$0}"
+
+  # User provided
   if [[ -n "${ASDF_GOLANG_CANON_GO_PATH:-}" ]]; then
-    echo "$ASDF_GOLANG_CANON_GO_PATH"
-    return
-  fi
-
-  # Try PATH
-  local go_path
-  go_path=$(command -v go 2>/dev/null || true)
-
-  if [[ -z "$go_path" || "$go_path" == *"/shims/go" ]]; then
-    # Try ASDF_INSTALL_PATH
-    local install_path="${ASDF_INSTALL_PATH:-}"
-    if [[ -n "$install_path" && -x "$install_path/go/bin/go" ]]; then
-      echo "$install_path/go/bin/go"
+    local p="$ASDF_GOLANG_CANON_GO_PATH"
+    if [[ -x "$p" && "$p" != "$self" && "$p" != *"/shims/go" ]]; then
+      echo "$p"
       return
     fi
+  fi
 
-    # Try asdf current version
-    local current_version
-    current_version=$(asdf current golang 2>/dev/null | awk '{print $2}' | head -n1)
-    if [[ -n "$current_version" ]]; then
-      local asdf_data_dir="${ASDF_DATA_DIR:-$HOME/.asdf}"
-      local asdf_go_path="$asdf_data_dir/installs/golang/$current_version/go/bin/go"
-      if [[ -x "$asdf_go_path" ]]; then
-        echo "$asdf_go_path"
-        return
-      fi
+  # Resolve using asdf
+  if command -v asdf >/dev/null 2>&1; then
+    local p
+    p=$(asdf which go 2>/dev/null || true)
+    if [[ -n "$p" && -x "$p" && "$p" != "$self" ]]; then
+      echo "$p"
+      return
     fi
-  elif [[ -x "$go_path" ]]; then
+  fi
+
+  # Fallback to PATH, but avoid recursion
+  local go_path
+  go_path=$(command -v go 2>/dev/null || true)
+  if [[ -n "$go_path" && -x "$go_path" && "$go_path" != "$self" && "$go_path" != *"/shims/go" ]]; then
     echo "$go_path"
     return
   fi
 
-  if [[ "$(command -v go 2>/dev/null)" == "$0" ]]; then
-    # Avoid recursion
-    echo "Could not resolve real Go binary (recursion detected)." >&2
-    exit 127
-  fi
-
-  # Fallback: system go
-  echo "go"
+  echo "Could not resolve real Go binary." >&2
+  exit 127
 }
 
 wrap_go_and_reshim() {
@@ -78,19 +66,23 @@ wrap_go_and_reshim() {
   canon_go_path=$(resolve_canon_go)
 
   if should_reshim "$@"; then
-    # Run original go command
+    # Run original command
     "$canon_go_path" "$@"
     local exit_code=$?
-    
+
     if [[ $exit_code -eq 0 ]]; then
-      # Command succeeded, reshim
-      echo "Reshimming asdf golang..." >&2
-      asdf reshim golang
+      if command -v asdf >/dev/null 2>&1; then
+        # Reshim asdf golang
+        echo "Reshimming asdf golang..." >&2
+        if ! asdf reshim golang; then
+          echo "Warning: asdf reshim failed." >&2
+        fi
+      fi
     fi
-    
+
     return $exit_code
   else
-    # Run original go command, no reshimming needed
+    # No reshim needed, run original command
     exec "$canon_go_path" "$@"
   fi
 }


### PR DESCRIPTION
## Issue
Since #152 added support for consistent GOBIN usage, a manual `asdf reshim golang` command was required after installing Go packages using `go install` or `go get`.

A related issue: #131

## Changes
This PR adds an automatic reshimming feature similar to implementations in [asdf-python](https://github.com/asdf-community/asdf-python/blob/master/shims/pip) and [asdf-nodejs](https://github.com/asdf-vm/asdf-nodejs/blob/master/shims/npm). The `go` command is wrapped to automatically call `asdf reshim golang` after `go install` and legacy `go get` commands, eliminating the need for manual reshimming.

Additional features:
- Option to skip reshimming with `ASDF_GOLANG_SKIP_RESHIM=1` environment variable
- Custom Go path configuration via `ASDF_GOLANG_CANON_GO_PATH` environment variable

---

**Note:** I’ll be away next week. @ofalvai can help with handling the follow-ups for this PR, with @pgyula as a backup.