### PR TITLE
Error if version not in `MAJOR.MINOR.PATCH` format

### DIFF
--- a/bin/download
+++ b/bin/download
@@ -32,6 +32,9 @@ download_golang() {
   local platform=""
   local arch=""
 
+  # Validate version format before attempting download
+  validate_version "$version"
+
   platform=$(get_platform)
   arch=$(get_arch)
   download_url="https://dl.google.com/go/go${version}.${platform}-${arch}.tar.gz"

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -39,6 +39,16 @@ get_arch() {
   printf "%s" "$arch"
 }
 
+validate_version() {
+  local version="$1"
+
+  # Check if version matches the pattern major.minor.patch
+  # This allows for versions like 1.21.0, 1.22.1, etc.
+  if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    fail "Invalid version format: '$version'. Go versions must be in the format 'major.minor.patch' (e.g., '1.25.0')."
+  fi
+}
+
 msg() {
   echo -e "\033[32m$1\033[39m" >&2
 }


### PR DESCRIPTION
## Problem

Was running into this error when trying to install go 1.25:

```
> asdf install golang 1.25
Invalid version format: '1.25'. Go versions must be in the format 'major.minor.patch' (e.g., '1.25.0').
```

Took me a while to realize that the issue is that the version has to be in `MAJOR.MINOR.PATCH` format, e.g. 

this
```
asdf install golang 1.25
```

not this
```
asdf install golang 1.25.0
```

## Fix

This pull request introduces a new utility function to validate version strings in the `lib/helpers.sh` script. The main change is the addition of a function that ensures version numbers conform to the expected `major.minor.patch` format.